### PR TITLE
Update main.css Fixed cloud text cutoff

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2630,7 +2630,7 @@
 			@media screen and (max-width: 1280px) {
 
 				.wrapper > .inner {
-					width: 90%;
+					width: 80%;
 				}
 
 			}


### PR DESCRIPTION
Fixed cloud text cutoff in the rocketship div.
<img width="1263" alt="screen shot 2015-11-22 at 1 36 19 am" src="https://cloud.githubusercontent.com/assets/9068012/11322444/9f008a90-90b9-11e5-9f05-d383a2481606.png">

Proposed fix:
<img width="1272" alt="screen shot 2015-11-22 at 1 38 11 am" src="https://cloud.githubusercontent.com/assets/9068012/11322449/c48b5290-90b9-11e5-9edc-b16d17e2a104.png">
